### PR TITLE
Changing start condition to handle both master and main

### DIFF
--- a/gatsby/.platform.app.yaml
+++ b/gatsby/.platform.app.yaml
@@ -25,7 +25,7 @@ disk: 1024
 web:
     commands:
         start: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
+            if [ "$PLATFORM_BRANCH" = "master" ] || [ "$PLATFORM_BRANCH" = "main" ]; then
                npm run serve -- -p $PORT
             # Run development server on non-production environments.
             else


### PR DESCRIPTION
The template provides with different start command depending on the branch used. Platform.sh new default being "main", it wasn't covered by the template.
Instead of replacing master by main, I added an "or" condition to handle both.