### PR TITLE
Update .platform.app.yaml

### DIFF
--- a/gatsby/.platform.app.yaml
+++ b/gatsby/.platform.app.yaml
@@ -34,7 +34,7 @@ disk: 1024
 web:
     commands:
         start: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
+            if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then
                yarn run serve -- -p $PORT
             # Run development server on non-production environments.
             else


### PR DESCRIPTION
gatsby fails to start if your production branch is not named "master". Changes check at line 37 to look at the environment type vs name